### PR TITLE
add first test: admin interface

### DIFF
--- a/djangoforce/djangoforce/test_module/test_responses.py
+++ b/djangoforce/djangoforce/test_module/test_responses.py
@@ -1,0 +1,14 @@
+import pytest
+
+@pytest.mark.django_db
+def test_welcome_django(admin_client):
+    """
+    Asserts whether the admin page sends a 200 HTTP status code as response
+
+    200 means that the HTTP request was successful. Tests for the admin
+    pages are done with the admin_client. The URL and port may vary. The
+    fixture above the function allows the function to access the database.
+    """
+    response = admin_client.get("http://localhost:8000/admin/")
+    assert response.status_code == 200
+

--- a/djangoforce/pytest.ini
+++ b/djangoforce/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=djangoforce.settings


### PR DESCRIPTION
This PR adds the first test. The server needs to run for the test to work. It just checks whether the admin interface is reachable. To run the test yourself you need to have pytest and pytest-django installed. In the directory with the pytest.ini file run `pytest` or `python3 -m pytest`.

![bildschirmfoto von 2015-08-26 00-02-35](https://cloud.githubusercontent.com/assets/6953323/9480952/9be3f0c2-4b86-11e5-9044-abe1b925726b.png)
